### PR TITLE
Fix: Payment price is always shown in checkout

### DIFF
--- a/views/blocks/azure/page/checkout/payment/select_payment.tpl
+++ b/views/blocks/azure/page/checkout/payment/select_payment.tpl
@@ -19,7 +19,9 @@
             <label for="payment_[{$sPaymentID}]"><b>[{ $paymentmethod->oxpayments__oxdesc->value }] [{if $payment_mode eq 0}]SANDBOX Mode[{/if}]</b>
             [{if $paymentmethod->getPrice()}]
                 [{assign var="oPaymentPrice" value=$paymentmethod->getPrice() }]
-                ([{$oPaymentPrice->getBruttoPrice()|number_format:2:".":","}] [{ $currency->sign}])
+                [{if $oPaymentPrice->getBruttoPrice()}]
+                    ([{$oPaymentPrice->getBruttoPrice()|number_format:2:".":","}] [{ $currency->sign}])
+                [{/if}]
             [{/if}]
             </label>
         </dt>


### PR DESCRIPTION
Calling `getPrice()` on `$paymentmethod` returns a price object.
Therefore the if always returns true and the price for the payment option is always shown in checkout.
Apparently OXID/Smarty does not like chaining methods in an if so we can't do `->getPrice()->getBruttoPrice()`.
Using another if fixes this problem and the price is only shown if a price is set for the payment option.